### PR TITLE
Speed up build process by caching layer with application dependencies

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -15,6 +15,10 @@ ONBUILD RUN mkdir -m 0600 ~/.ssh \
     && chmod 600 ~/.ssh/id_rsa \
     && ssh-keygen -p -f ~/.ssh/id_rsa -P "${SSH_PRIVATE_KEY_PASSPHRASE}" -N ""
 
+ONBUILD COPY go.mod go.sum ./
+
+ONBUILD RUN go mod download
+
 ONBUILD COPY . ./
 
 ONBUILD RUN go fmt ./... && go build -o /tmp/app


### PR DESCRIPTION
Previously dependencies got downloaded on any change in Docker build context.
Now it happens only when there is a change in go.mod or go.sum.

Article I used to validate that my idea was right: https://medium.com/@petomalina/using-go-mod-download-to-speed-up-golang-docker-builds-707591336888