### PR TITLE
Add GOPRIVATE env to builder to allow go mod download to work - bump …

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.15-alpine as builder
 
-RUN apk add --no-cache git=~2.26 openssh-client=~8.3 build-base=~0.5
+ENV GOPRIVATE="github.com/companieshouse"
+
+RUN apk add --no-cache git=~2.30 openssh-client=~8.4 build-base=~0.5
 
 RUN git config --global url."git@github.com:".insteadOf https://github.com/
 


### PR DESCRIPTION
…git and openssh-client deps