### PR TITLE
Bump APK versions for git and openSSH client

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.16-alpine as builder
 
 ENV GOPRIVATE="github.com/companieshouse"
 
-RUN apk add --no-cache git=~2.32 openssh-client=~8.6 build-base=~0.5
+RUN apk add --no-cache git openssh-client build-base
 
 RUN git config --global url."git@github.com:".insteadOf https://github.com/
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.16-alpine as builder
 
 ENV GOPRIVATE="github.com/companieshouse"
 
-RUN apk add --no-cache git=~2.30 openssh-client=~8.4 build-base=~0.5
+RUN apk add --no-cache git=~2.32 openssh-client=~8.6 build-base=~0.5
 
 RUN git config --global url."git@github.com:".insteadOf https://github.com/
 


### PR DESCRIPTION
When rebuilding the docker image it encountered
an error due to a later version of each of the apk's
breaking the version we use (security fixes).

Bumped the versions to get the image to build correctly.