### PR TITLE
Feature/bump go version to 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ To fix this you can disable BuildKit in one of two ways:
 ## Supported images
 
 | Tag                                                                            | OS         | Go version |
-| ------------------------------------------------------------------------------ | ---------- | ---------- |
+|--------------------------------------------------------------------------------| ---------- |------------|
 | `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-builder` | Alpine     | 1.15.x     |
 | `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-builder` | Alpine     | 1.16.x     |
+| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.19-alpine-builder` | Alpine     | 1.19.x     |
 | `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:alpine-runtime`      | Alpine     | None       |
 
 ## Image properties

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ To fix this you can disable BuildKit in one of two ways:
 
 ## Supported images
 
-| Tag                                                                            | OS         | Go version |
-|--------------------------------------------------------------------------------| ---------- |------------|
-| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-builder` | Alpine     | 1.15.x     |
-| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-builder` | Alpine     | 1.16.x     |
-| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.19-alpine-builder` | Alpine     | 1.19.x     |
-| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:alpine-runtime`      | Alpine     | None       |
+| Tag                                                                            | OS     | Go version |
+|--------------------------------------------------------------------------------|--------|------------|
+| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-builder` | Alpine | 1.15.x     |
+| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-builder` | Alpine | 1.16.x     |
+| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.19-alpine-builder` | Debian | 1.19.x     |
+| `169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:alpine-runtime`      | Alpine | None       |
 
 ## Image properties
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.19.6-bullseye as builder
 
 ENV GOPRIVATE="github.com/companieshouse"
 
-RUN apt update && \
-    apt install \
+RUN apt-get update && \
+    apt-get install \
     git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.19.6-bullseye as builder
 ENV GOPRIVATE="github.com/companieshouse"
 
 RUN apt-get update && \
-    apt-get install \
+    apt-get install -y --no-install-recommends\
     git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as builder
+FROM golang:1.19.6-alpine as builder
 
 ENV GOPRIVATE="github.com/companieshouse"
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.19.6-alpine as builder
+FROM golang:1.19.6-bullseye as builder
 
 ENV GOPRIVATE="github.com/companieshouse"
 
-RUN apk add --no-cache git openssh-client build-base
+RUN apt update && \
+    apt install \
+    git && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN git config --global url."git@github.com:".insteadOf https://github.com/
 

--- a/builder/version
+++ b/builder/version
@@ -1,1 +1,1 @@
-1.16-alpine-builder
+1.19-alpine-builder

--- a/builder/version
+++ b/builder/version
@@ -1,1 +1,1 @@
-1.19-alpine-builder
+1.19-bullseye-builder

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.17
 
 WORKDIR /app
 

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM debian:bullseye
 
 WORKDIR /app
 

--- a/runtime/version
+++ b/runtime/version
@@ -1,1 +1,1 @@
-alpine-runtime
+debian11-runtime


### PR DESCRIPTION
Go 1.19 version of ci-golang-build has been built on debian bullseye as there were some issues with alpine. Hence moving the base image also to Debian 11.