### PR TITLE
Add ca-certificates package to runtime image

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,5 +1,10 @@
 FROM debian:bullseye
 
+RUN apt-get update && \
+    apt-get install -y --allow-downgrades --no-install-recommends\
+    ca-certificates=20210119 && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 ONBUILD COPY --from=0 /tmp/app ./


### PR DESCRIPTION
Discovered while testing insolvency-api that the ca-certificates package is required for connectivity to file-transfer-api